### PR TITLE
docs(example): Add googlebatch_container_dependencies_installed to RE…

### DIFF
--- a/example/hello-world-cos/README.md
+++ b/example/hello-world-cos/README.md
@@ -25,6 +25,7 @@ rule interpolated_flat_fluvial:
         googlebatch_entrypoint="/docker-entrypoint.sh",
         googlebatch_machine_type="e2-standard-4",
         googlebatch_container="europe-docker.pkg.dev/myproject/my_image_name:latest",
+        googlebatch_container_dependencies_installed=True,
         googlebatch_work_tasks=1,
         googlebatch_work_tasks_per_node=2,
     script:


### PR DESCRIPTION
…ADME example

- In `example/hello-world-cos/README.md`, added `googlebatch_container_dependencies_installed=True` to the `googlebatch` configuration for the `interpolated_flat_fluvial` rule.
- This updates the example to demonstrate how to specify that container dependencies are pre-installed for Google Batch jobs, which can affect how the job runner prepares the environment.