### PR TITLE
refactor(executor): Simplify task runnable assignment and update log …

### DIFF
--- a/snakemake_executor_plugin_googlebatch/executor.py
+++ b/snakemake_executor_plugin_googlebatch/executor.py
@@ -232,7 +232,7 @@ class GoogleBatchExecutor(RemoteExecutor):
             preemptible = all(is_p(rule) for rule in job.rules)
         else:
             preemptible = is_p(job.rule.name)
-        self.logger.info(f"Is this job pre-emptible: {preemptible}")
+        self.logger.info(f"pre-emptible rules: {preemptible}")
         return preemptible
 
     def get_command_writer(self, job):
@@ -334,9 +334,7 @@ class GoogleBatchExecutor(RemoteExecutor):
         barrier = batch_v1.Runnable()
         barrier.barrier = batch_v1.Runnable.Barrier()
         barrier.barrier.name = "wait-for-setup"
-        task.runnables = [setup, snakefile_step]
-
-        task.runnables.extend([barrier, runnable])
+        task.runnables = [setup, snakefile_step, barrier, runnable]
 
         # Are we adding storage?
         self.add_storage(job, task)


### PR DESCRIPTION
…message

- In `snakemake_executor_plugin_googlebatch/executor.py`, the assignment of `task.runnables` was simplified. Instead of initializing the list with `[setup, snakefile_step]` and then extending it with `[barrier, runnable]`, the list is now initialized directly with all four elements: `[setup, snakefile_step, barrier, runnable]`. This change is a code simplification and has no functional impact on the order or content of the runnables.
- In `snakemake_executor_plugin_googlebatch/executor.py`, the log message for checking preemptible jobs was updated from "Is this job pre-emptible: {preemptible}" to "pre-emptible rules: {preemptible}". This is a cosmetic change to the logging output for improved clarity.