### PR TITLE
build: Switch package build and publish to uv

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,4 +38,6 @@ jobs:
         env:
           PYPI_USERNAME: __token__
           PYPI_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: flit publish --build --username $PYPI_USERNAME --password $PYPI_PASSWORD
+        run: |
+          uv build
+          uv publish --build --username $PYPI_USERNAME --password $PYPI_PASSWORD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["flit-core >=3.12,<4"]
-build-backend = "flit_core.buildapi"
-
 [project]
 name = "snakemake-executor-plugin-googlebatch"
 version = "0.6.0"


### PR DESCRIPTION
- `.github/workflows/release-please.yml`: Replaced `flit publish` with `uv build` and `uv publish` for building and uploading the package to PyPI. This changes the CI/CD pipeline to use `uv` for package distribution.
- `pyproject.toml`: Removed the `[build-system]` section, which previously declared `flit-core` as the build backend. This change removes the explicit build system declaration, as `uv` will now manage the build process.